### PR TITLE
README tweaks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,20 +1,5 @@
-*****************************************************************
-testscenarios: extensions to python unittest to support scenarios
-*****************************************************************
-
-  Copyright (c) 2009, Robert Collins <robertc@robertcollins.net>
-  
-  Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
-  license at the users choice. A copy of both licenses are available in the
-  project source as Apache-2.0 and BSD. You may not use this file except in
-  compliance with one of these two licences.
-  
-  Unless required by applicable law or agreed to in writing, software
-  distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
-  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-  license you chose for the specific language governing permissions and
-  limitations under that license.
-
+testscenarios
+=============
 
 testscenarios provides clean dependency injection for python unittest style
 tests. This can be used for interface testing (testing many implementations via
@@ -22,23 +7,16 @@ a single test suite) or for classic dependency injection (provide tests with
 dependencies externally to the test code itself, allowing easy testing in
 different situations).
 
-Dependencies
-============
+Why TestScenarios?
+------------------
 
-* Python 3.10+
-* testtools <https://github.com/testing-cabal/testtools>
-
-
-Why TestScenarios
-=================
-
-Standard Python unittest.py provides on obvious method for running a single
-test_foo method with two (or more) scenarios: by creating a mix-in that
+``unittest`` provides on obvious method for running a single ``test_foo``
+method with two (or more) scenarios: by creating a mix-in that
 provides the functions, objects or settings that make up the scenario. This is
 however limited and unsatisfying. Firstly, when two projects are cooperating
 on a test suite (for instance, a plugin to a larger project may want to run
 the standard tests for a given interface on its implementation), then it is
-easy for them to get out of sync with each other: when the list of TestCase
+easy for them to get out of sync with each other: when the list of ``TestCase``
 classes to mix-in with changes, the plugin will either fail to run some tests
 or error trying to run deleted tests. Secondly, its not as easy to work with
 runtime-created-subclasses (a way of dealing with the aforementioned skew)
@@ -49,9 +27,8 @@ It is the intent of testscenarios to make dynamically running a single test
 in multiple scenarios clear, easy to debug and work with even when the list
 of scenarios is dynamically generated.
 
-
 Defining Scenarios
-==================
+------------------
 
 A **scenario** is a tuple of a string name for the scenario, and a dict of
 parameters describing the scenario.  The name is appended to the test name, and
@@ -62,7 +39,7 @@ but may be any iterable.
 
 
 Getting Scenarios applied
-=========================
+-------------------------
 
 At its heart the concept is simple. For a given test object with a list of
 scenarios we prepare a new test object for each scenario. This involves:
@@ -75,56 +52,58 @@ There are some complicating factors around making this happen seamlessly. These
 factors are in two areas:
 
 * Choosing what scenarios to use. (See Setting Scenarios For A Test).
-* Getting the multiplication to happen. 
+* Getting the multiplication to happen.
 
 Subclasssing
-++++++++++++
+~~~~~~~~~~~~
 
-If you can subclass TestWithScenarios, then the ``run()`` method in
-TestWithScenarios will take care of test multiplication. It will at test
-execution act as a generator causing multiple tests to execute. For this to 
-work reliably TestWithScenarios must be first in the MRO and you cannot
-override run() or __call__. This is the most robust method, in the sense
-that any test runner or test loader that obeys the python unittest protocol
-will run all your scenarios.
+If you can subclass ``TestWithScenarios``, then the ``run()`` method in
+``TestWithScenarios`` will take care of test multiplication. It will at test
+execution act as a generator causing multiple tests to execute. For this to
+work reliably ``TestWithScenarios`` must be first in the MRO and you cannot
+override ``run()`` or ``__call__``. This is the most robust method, in the
+sense that any test runner or test loader that obeys the python unittest
+protocol will run all your scenarios.
 
 Manual generation
-+++++++++++++++++
+~~~~~~~~~~~~~~~~~
 
-If you cannot subclass TestWithScenarios (e.g. because you are using
-TwistedTestCase, or TestCaseWithResources, or any one of a number of other
-useful test base classes, or need to override run() or __call__ yourself) then 
-you can cause scenario application to happen later by calling
-``testscenarios.generate_scenarios()``. For instance::
+If you cannot subclass ``TestWithScenarios`` (e.g. because you are using
+``TwistedTestCase``, or ``TestCaseWithResources``, or any one of a number of
+other useful test base classes, or need to override ``run()`` or ``__call__``
+yourself) then you can cause scenario application to happen later by calling
+``testscenarios.generate_scenarios()``. For instance:
+
+.. code-block:: python
 
   >>> import unittest
-  >>> try:
-  ...     from StringIO import StringIO
-  ... except ImportError:
-  ...     from io import StringIO
+  >>> from io import StringIO
   >>> from testscenarios.scenarios import generate_scenarios
 
 This can work with loaders and runners from the standard library, or possibly other
-implementations::
+implementations:
+
+.. code-block:: python
 
   >>> loader = unittest.TestLoader()
   >>> test_suite = unittest.TestSuite()
   >>> runner = unittest.TextTestRunner(stream=StringIO())
-
   >>> mytests = loader.loadTestsFromNames(['doc.test_sample'])
   >>> test_suite.addTests(generate_scenarios(mytests))
   >>> runner.run(test_suite)
   <unittest...TextTestResult run=1 errors=0 failures=0>
 
 Testloaders
-+++++++++++
+~~~~~~~~~~~
 
 Some test loaders support hooks like ``load_tests`` and ``test_suite``.
 Ensuring your tests have had scenario application done through these hooks can
 be a good idea - it means that external test runners (which support these hooks
 like ``nose``, ``trial``, ``tribunal``) will still run your scenarios. (Of
 course, if you are using the subclassing approach this is already a surety).
-With ``load_tests``::
+With ``load_tests``:
+
+.. code-block:: python
 
   >>> def load_tests(standard_tests, module, loader):
   ...     result = loader.suiteClass()
@@ -132,7 +111,9 @@ With ``load_tests``::
   ...     return result
 
 as a convenience, this is available in ``load_tests_apply_scenarios``, so a
-module using scenario tests need only say ::
+module using scenario tests need only say:
+
+.. code-block:: python
 
   >>> from testscenarios import load_tests_apply_scenarios as load_tests
 
@@ -151,16 +132,18 @@ With ``test_suite``::
 
 
 Setting Scenarios for a test
-============================
+----------------------------
 
-A sample test using scenarios can be found in the doc/ folder.
+A sample test using scenarios can be found in the ``doc/`` folder.
 
 See `pydoc testscenarios` for details.
 
 On the TestCase
-+++++++++++++++
+~~~~~~~~~~~~~~~
 
-You can set a scenarios attribute on the test case::
+You can set a scenarios attribute on the test case:
+
+.. code-block:: python
 
   >>> class MyTest(unittest.TestCase):
   ...
@@ -172,12 +155,14 @@ This provides the main interface by which scenarios are found for a given test.
 Subclasses will inherit the scenarios (unless they override the attribute).
 
 After loading
-+++++++++++++
+~~~~~~~~~~~~~
 
 Test scenarios can also be generated arbitrarily later, as long as the test has
 not yet run. Simply replace (or alter, but be aware that many tests may share a
 single scenarios attribute) the scenarios attribute. For instance in this
-example some third party tests are extended to run with a custom scenario. ::
+example some third party tests are extended to run with a custom scenario.
+
+.. code-block:: python
 
   >>> import testtools
   >>> class TestTransport:
@@ -197,7 +182,9 @@ example some third party tests are extended to run with a custom scenario. ::
 Generated tests don't have a ``scenarios`` list, because they don't normally
 require any more expansion.  However, you can add a ``scenarios`` list back on
 to them, and then run them through ``generate_scenarios`` again to generate the
-cross product of tests. ::
+cross product of tests.
+
+.. code-block:: python
 
   >>> class CrossProductDemo(unittest.TestCase):
   ...     scenarios = [('scenario_0_0', {}),
@@ -209,7 +196,7 @@ cross product of tests. ::
   >>> suite.addTests(generate_scenarios(CrossProductDemo("test_foo")))
   >>> for test in testtools.iterate_tests(suite):
   ...     test.scenarios = [
-  ...         ('scenario_1_0', {}), 
+  ...         ('scenario_1_0', {}),
   ...         ('scenario_1_1', {})]
   ...
   >>> suite2 = unittest.TestSuite()
@@ -218,13 +205,15 @@ cross product of tests. ::
   4
 
 Dynamic Scenarios
-+++++++++++++++++
+~~~~~~~~~~~~~~~~~
 
 A common use case is to have the list of scenarios be dynamic based on plugins
 and available libraries. An easy way to do this is to provide a global scope
 scenarios somewhere relevant to the tests that will use it, and then that can
 be customised, or dynamically populate your scenarios from a registry etc.
-For instance::
+For instance:
+
+.. code-block:: python
 
   >>> hash_scenarios = []
   >>> try:
@@ -250,7 +239,7 @@ For instance::
 
 
 Forcing Scenarios
-+++++++++++++++++
+~~~~~~~~~~~~~~~~~
 
 The ``apply_scenarios`` function can be useful to apply scenarios to a test
 that has none applied. ``apply_scenarios`` is the workhorse for
@@ -262,13 +251,13 @@ selection.
 
 
 Generating Scenarios
-====================
+--------------------
 
 Some functions (currently one :-) are available to ease generation of scenario
 lists for common situations.
 
 Testing Per Implementation Module
-+++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 It is reasonably common to have multiple Python modules that provide the same
 capabilities and interface, and to want apply the same tests to all of them.
@@ -293,24 +282,44 @@ testscenarios will not magically stop it being used.
 
 
 Advice on Writing Scenarios
-===========================
+---------------------------
 
 If a parameterised test is because of a bug run without being parameterized,
 it should fail rather than running with defaults, because this can hide bugs.
 
 
 Producing Scenarios
-===================
+-------------------
 
-The `multiply_scenarios` function produces the cross-product of the scenarios
-passed in::
+The ``multiply_scenarios`` function produces the cross-product of the scenarios
+passed in:
+
+.. code-block:: python
 
   >>> from testscenarios.scenarios import multiply_scenarios
-  >>> 
+  >>>
   >>> scenarios = multiply_scenarios(
   ...      [('scenario1', dict(param1=1)), ('scenario2', dict(param1=2))],
-  ...      [('scenario2', dict(param2=1))],
-  ...      )
-  >>> scenarios == [('scenario1,scenario2', {'param2': 1, 'param1': 1}),
-  ...               ('scenario2,scenario2', {'param2': 1, 'param1': 2})]
+  ...      [('scenario2', dict(param2=1))])
+  >>> scenarios == [
+  ...      ('scenario1,scenario2', {'param2': 1, 'param1': 1}),
+  ...      ('scenario2,scenario2', {'param2': 1, 'param1': 2})]
   True
+
+License
+-------
+
+::
+
+  Copyright (c) 2009, Robert Collins <robertc@robertcollins.net>
+
+  Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
+  license at the users choice. A copy of both licenses are available in the
+  project source as Apache-2.0 and BSD. You may not use this file except in
+  compliance with one of these two licences.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  license you chose for the specific language governing permissions and
+  limitations under that license.


### PR DESCRIPTION
* Move the license to the end
* Use the code-blocks directive for prettier highlighting
* Use more "normal" header underlines
* Remove some Python 2-isms

Signed-off-by: Stephen Finucane <stephen@that.guru>
