### PR TITLE
Publish release on all tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,4 +36,4 @@ jobs:
         run: hatch build
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/2')
+        if: github.event_name == 'push' && github.ref_type == 'tag'


### PR DESCRIPTION
Unlike testtools, we're not at a 2.x release yet. There also shouldn't be any other tag here so we can just publish on any tag.
