### PR TITLE
Fix load_tests hook to match unittest discovery

### DIFF
--- a/testscenarios/__init__.py
+++ b/testscenarios/__init__.py
@@ -57,7 +57,7 @@ def test_suite():
     return testscenarios.tests.test_suite()
 
 
-def load_tests(standard_tests, module, loader):
+def load_tests(loader, standard_tests, pattern):
     standard_tests.addTests(loader.loadTestsFromNames(["testscenarios.tests"]))
     return standard_tests
 

--- a/testscenarios/tests/__init__.py
+++ b/testscenarios/tests/__init__.py
@@ -15,20 +15,18 @@
 # limitations under that license.
 
 import doctest
-import sys
 import unittest
 
 import testscenarios
 
 
 def test_suite():
-    standard_tests = unittest.TestSuite()
-    module = sys.modules["testscenarios.tests"]
     loader = unittest.TestLoader()
-    return load_tests(standard_tests, module, loader)
+    standard_tests = unittest.TestSuite()
+    return load_tests(loader, standard_tests, None)
 
 
-def load_tests(standard_tests, module, loader):
+def load_tests(loader, standard_tests, pattern):
     test_modules = [
         "testcase",
         "scenarios",


### PR DESCRIPTION
unittest calls `load_tests(loader, standard_tests, pattern)` while the old bzr-style `(standard_tests, module, loader)` order made the loader look like a suite and broke `addTests` under `python -m unittest`.

~~~
/usr/bin/python3 -m unittest -v
test_so_easy (doc.test_sample.TestSample.test_so_easy) ... ok
testscenarios (unittest.loader._FailedTest.testscenarios) ... ERROR

======================================================================
ERROR: testscenarios (unittest.loader._FailedTest.testscenarios)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builddir/build/BUILD/python-testscenarios-0.6-build/testscenarios-0.6/testscenarios/__init__.py", line 61, in load_tests
    standard_tests.addTests(loader.loadTestsFromNames(["testscenarios.tests"]))
    ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'TestLoader' object has no attribute 'addTests'

----------------------------------------------------------------------
Ran 2 tests in 0.000s
~~~