### PR TITLE
Include tests in the source distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,4 +59,5 @@ include = [
     "NEWS",
     "README.rst",
     "doc/*.py",
+    "tests/*.py",
     ]


### PR DESCRIPTION
Explicitly include `tests` in the source distribution.  They were moved out of the package in 42e820a86b36d96ccf840ea69139194f9014fa8c, but the file list wasn't updated to include them.